### PR TITLE
チーム情報の操作に関しての機能を調整

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -31,6 +31,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif current_user != assigned_user && current_user != assign.team.owner
+      I18n.t('views.messages.cannot_delete_another_member')
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy leader_authority]
+  before_action :leader_authority, only: %i[edit update destroy]
 
   def index
     @teams = Team.all
@@ -56,4 +57,9 @@ class TeamsController < ApplicationController
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
+
+  def leader_authority
+    redirect_to @team unless @team.owner == current_user
+  end
+
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user == @team.owner %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,6 +214,7 @@ ja:
       does_not_exist_email: 'メールアドレスが存在しません。アカウントを作成してください。'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
+      cannot_delete_another_member: '自分以外のメンバーは削除できません。'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'


### PR DESCRIPTION
#1
・Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにする
・TeamのeditはTeamのリーダー（オーナー）のみができるようにする
という仕様変更を対応しました。